### PR TITLE
Hotfix/cicd https error

### DIFF
--- a/src/MeetlyOmni.IntegrationTests/HealthCheckTests.cs
+++ b/src/MeetlyOmni.IntegrationTests/HealthCheckTests.cs
@@ -15,7 +15,7 @@ public class BackendStatusTests
             Timeout = TimeSpan.FromSeconds(30)
         };
 
-        var baseUrl = LaunchSettingsReader.GetBaseUrl();
+        var baseUrl = Environment.GetEnvironmentVariable("BASE_URL") ?? LaunchSettingsReader.GetBaseUrl("http");
         var response = await httpClient.GetAsync($"{baseUrl}/swagger/index.html");
 
         Assert.True(response.IsSuccessStatusCode, $"Backend is not available. Status: {response.StatusCode}, Reason: {response.ReasonPhrase}");

--- a/src/MeetlyOmni.IntegrationTests/LaunchSettingsReader.cs
+++ b/src/MeetlyOmni.IntegrationTests/LaunchSettingsReader.cs
@@ -6,7 +6,7 @@ namespace MeetlyOmni.IntegrationTests;
 
 public static class LaunchSettingsReader
 {
-    public static string GetBaseUrl(string profileName = "http")
+    public static string GetBaseUrl(string profileName = "https")
     {
         if (string.IsNullOrWhiteSpace(profileName))
         {


### PR DESCRIPTION
Hotfix/cicd https error change 
// defied GetBaseUrl in LaunchSettingsReader as GetBaseUrl(string profileName = "https")
 var baseUrl = LaunchSettingsReader.GetBaseUrl();
 // new
 var baseUrl = Environment.GetEnvironmentVariable("BASE_URL")
    ?? LaunchSettingsReader.GetBaseUrl("http");

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Integration health check tests now support overriding the base URL via an environment variable, improving flexibility across environments (CI/CD, staging, local).
  - Falls back to a sensible default when the variable isn’t set, enhancing test reliability and consistency.
  - No impact on user-facing functionality; these changes are limited to internal testing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->