### PR TITLE
fix:change sdk to 8.0.414 to avoid github build error

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.315",
+    "version": "8.0.414",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
change global.json from .Net sdk 8.0.315 to 8.0.414 to avoid github build error
 <img width="982" height="490" alt="image" src="https://github.com/user-attachments/assets/a9c99f05-c09f-43c2-acaa-c95a902063a3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the .NET SDK version used by the project to 8.0.414 (roll-forward to latest patch) to align with the latest fixes and improvements.
  * Ensures consistent builds across local and CI environments by standardizing the SDK version.
  * No changes to application features or behavior; this affects tooling and build configuration only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->