### PR TITLE
Feature/57 implement email service

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -104,3 +104,4 @@ dotnet_diagnostic.SA1101.severity = none   # Prefix local calls with 'this'
 dotnet_diagnostic.IDE0003.severity = none  # Remove 'this' qualification
 dotnet_diagnostic.SA1018.severity = none
 dotnet_diagnostic.SA1011.severity = none
+dotnet_diagnostic.SA1206.severity = none # remove required should before public

--- a/src/MeetlyOmni.Api/Common/Enums/EmailType/EmailType.cs
+++ b/src/MeetlyOmni.Api/Common/Enums/EmailType/EmailType.cs
@@ -1,0 +1,11 @@
+﻿// <copyright file="EmailType.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+namespace MeetlyOmni.Api.Common.Enums.EmailType;
+
+public enum EmailType
+{
+    ResetPassword = 0,
+    VerifyEmail = 1,
+}

--- a/src/MeetlyOmni.Api/Common/Extensions/CookieExtensions.cs
+++ b/src/MeetlyOmni.Api/Common/Extensions/CookieExtensions.cs
@@ -11,7 +11,7 @@ namespace MeetlyOmni.Api.Common.Extensions;
 /// </summary>
 public static class AuthCookieExtensions
 {
-    private static CookieOptions CreateDeletionCookieOptions()
+    public static CookieOptions CreateDeletionCookieOptions()
         => new()
         {
             HttpOnly = true,

--- a/src/MeetlyOmni.Api/Common/Extensions/CookieExtensions.cs
+++ b/src/MeetlyOmni.Api/Common/Extensions/CookieExtensions.cs
@@ -11,6 +11,19 @@ namespace MeetlyOmni.Api.Common.Extensions;
 /// </summary>
 public static class AuthCookieExtensions
 {
+    private static CookieOptions CreateDeletionCookieOptions()
+        => new()
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.None,
+            Path = CookiePaths.Root,
+            Expires = DateTimeOffset.UnixEpoch,
+            IsEssential = true,
+
+            // Domain = ".your-domain.com"   // production; localhost should not be set
+        };
+
     public static CookieOptions CreateRefreshTokenCookieOptions(DateTimeOffset expiresAt)
         => new()
         {
@@ -57,10 +70,10 @@ public static class AuthCookieExtensions
         => resp.Cookies.Append(CookieNames.CsrfToken, csrfToken, CreateCsrfTokenCookieOptions());
 
     public static void DeleteRefreshTokenCookie(this HttpResponse resp)
-        => resp.Cookies.Delete(CookieNames.RefreshToken, new CookieOptions { Path = CookiePaths.Root });
+        => resp.Cookies.Delete(CookieNames.RefreshToken, CreateDeletionCookieOptions());
 
     public static void DeleteAccessTokenCookie(this HttpResponse resp)
-        => resp.Cookies.Delete(CookieNames.AccessToken, new CookieOptions { Path = CookiePaths.Root });
+        => resp.Cookies.Delete(CookieNames.AccessToken, CreateDeletionCookieOptions());
 
     public static class CookieNames
     {

--- a/src/MeetlyOmni.Api/Controllers/AuthController.cs
+++ b/src/MeetlyOmni.Api/Controllers/AuthController.cs
@@ -61,6 +61,7 @@ public class AuthController : ControllerBase
         _clientInfoService = clientInfoService;
         _antiforgery = antiforgery;
         _logger = logger;
+        _logoutService = logoutService;
         _signUpService = signUpService;
         _emailLinkService = emailLinkService;
         _accountMailer = accountMailer;

--- a/src/MeetlyOmni.Api/Controllers/AuthController.cs
+++ b/src/MeetlyOmni.Api/Controllers/AuthController.cs
@@ -8,13 +8,17 @@ using Asp.Versioning;
 
 using MeetlyOmni.Api.Common.Constants;
 using MeetlyOmni.Api.Common.Extensions;
+using MeetlyOmni.Api.Data.Entities;
 using MeetlyOmni.Api.Middlewares.Antiforgery;
 using MeetlyOmni.Api.Models.Auth;
 using MeetlyOmni.Api.Service.AuthService.Interfaces;
 using MeetlyOmni.Api.Service.Common.Interfaces;
+using MeetlyOmni.Api.Service.Email;
+using MeetlyOmni.Api.Service.Email.Interfaces;
 
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 
 namespace MeetlyOmni.Api.Controllers;
@@ -34,6 +38,9 @@ public class AuthController : ControllerBase
     private readonly ILogger<AuthController> _logger;
     private readonly ILogoutService _logoutService;
     private readonly ISignUpService _signUpService;
+    private readonly IEmailLinkService _emailLinkService;
+    private readonly AccountMailer _accountMailer;
+    private readonly UserManager<Member> _userManager;
 
     public AuthController(
         ILoginService loginService,
@@ -42,7 +49,10 @@ public class AuthController : ControllerBase
         IAntiforgery antiforgery,
         ILogger<AuthController> logger,
         ILogoutService logoutService,
-        ISignUpService signUpService)
+        ISignUpService signUpService,
+        IEmailLinkService emailLinkService,
+        AccountMailer accountMailer,
+        UserManager<Member> userManager)
     {
         _loginService = loginService;
         _tokenService = tokenService;
@@ -51,6 +61,9 @@ public class AuthController : ControllerBase
         _logger = logger;
         _logoutService = logoutService;
         _signUpService = signUpService;
+        _emailLinkService = emailLinkService;
+        _accountMailer = accountMailer;
+        _userManager = userManager;
     }
 
     /// <summary>
@@ -177,5 +190,100 @@ public class AuthController : ControllerBase
         var memberDto = await this._signUpService.SignUpAdminAsync(request);
 
         return StatusCode(StatusCodes.Status201Created, memberDto);
+    }
+
+    /// <summary>
+    /// Verify user's email address using the token from verification email.
+    /// </summary>
+    /// <param name="request">Email verification request containing email and token.</param>
+    /// <response code="200">Email successfully verified.</response>
+    /// <response code="400">Invalid request data or verification failed.</response>
+    /// <returns>A <see cref="Task{IActionResult}"/> representing the verification result.</returns>
+    [HttpPost("verify-email")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> VerifyEmail([FromBody] VerifyEmailRequest request, CancellationToken ct)
+    {
+        var isVerified = await _emailLinkService.ValidateAndConfirmEmailAsync(request.Email, request.Token, ct);
+
+        if (!isVerified)
+        {
+            _logger.LogWarning("Email verification failed for {Email}", request.Email);
+            return BadRequest(new { message = "Email verification failed. The token may be invalid or expired." });
+        }
+
+        _logger.LogInformation("Email successfully verified for {Email}", request.Email);
+
+        return Ok(new
+        {
+            message = "Email successfully verified. You can now log in to your account.",
+            email = request.Email,
+            verified = true,
+        });
+    }
+
+    /// <summary>
+    /// Request password reset email for a user.
+    /// </summary>
+    /// <param name="request">Forgot password request containing email.</param>
+    /// <response code="200">Password reset email sent (if email exists).</response>
+    /// <response code="400">Invalid request data.</response>
+    /// <returns>A <see cref="Task{IActionResult}"/> representing the operation result.</returns>
+    [HttpPost("forgot-password")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordRequest request, CancellationToken ct)
+    {
+        var user = await _userManager.FindByEmailAsync(request.Email);
+
+        if (user != null && user.EmailConfirmed)
+        {
+            await _accountMailer.SendResetPasswordAsync(user, ct);
+            _logger.LogInformation("Password reset email sent to {Email}", request.Email);
+        }
+        else
+        {
+            _logger.LogWarning("Password reset requested for non-existent or unconfirmed email: {Email}", request.Email);
+        }
+
+        // Always return success to prevent user enumeration
+        return Ok(new
+        {
+            message = "If the email address exists and is verified, a password reset link has been sent.",
+            email = request.Email,
+        });
+    }
+
+    /// <summary>
+    /// Reset user password using token from password reset email.
+    /// </summary>
+    /// <param name="request">Password reset request containing email, token, and new password.</param>
+    /// <response code="200">Password successfully reset.</response>
+    /// <response code="400">Invalid request data or password reset failed.</response>
+    /// <returns>A <see cref="Task{IActionResult}"/> representing the reset result.</returns>
+    [HttpPost("reset-password")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordRequest request, CancellationToken ct)
+    {
+        var isReset = await _emailLinkService.ResetPasswordAsync(request.Email, request.Token, request.NewPassword, ct);
+
+        if (!isReset)
+        {
+            _logger.LogWarning("Password reset failed for {Email}", request.Email);
+            return BadRequest(new { message = "Password reset failed. The token may be invalid or expired." });
+        }
+
+        _logger.LogInformation("Password successfully reset for {Email}", request.Email);
+
+        return Ok(new
+        {
+            message = "Password has been successfully reset. You can now log in with your new password.",
+            email = request.Email,
+            reset = true,
+        });
     }
 }

--- a/src/MeetlyOmni.Api/Controllers/AuthController.cs
+++ b/src/MeetlyOmni.Api/Controllers/AuthController.cs
@@ -2,6 +2,7 @@
 // Copyright (c) MeetlyOmni. All rights reserved.
 // </copyright>
 
+using System.Linq;
 using System.Security.Claims;
 
 using Asp.Versioning;
@@ -305,11 +306,14 @@ public class AuthController : ControllerBase
     [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordRequest request, CancellationToken ct)
     {
-        var isReset = await _resetPasswordService.ResetPasswordAsync(request.Email, request.Token, request.NewPassword, ct);
+        var resetResult = await _resetPasswordService.ResetPasswordAsync(request.Email, request.Token, request.NewPassword, ct);
 
-        if (!isReset)
+        if (!resetResult.Succeeded)
         {
-            return BadRequest(new { message = "Invalid or expired token" });
+            var message = resetResult.Errors.Any()
+                ? string.Join(", ", resetResult.Errors.Select(e => e.Description))
+                : "Invalid or expired token.";
+            return BadRequest(new { message });
         }
 
         return Ok(new { message = "Password reset", reset = true });

--- a/src/MeetlyOmni.Api/Mapping/MappingProfile.cs
+++ b/src/MeetlyOmni.Api/Mapping/MappingProfile.cs
@@ -5,11 +5,12 @@
 using AutoMapper;
 
 namespace MeetlyOmni.Api.Mapping;
+
 public class MappingProfile : Profile
 {
     public MappingProfile()
     {
-        // TODO: map your DTOs, for example:
-        // CreateMap<CreateUserDto, User>();
+        // TODO: Add your mapping configurations here when needed
+        // Example: CreateMap<Member, MemberDto>();
     }
 }

--- a/src/MeetlyOmni.Api/MeetlyOmni.Api.csproj
+++ b/src/MeetlyOmni.Api/MeetlyOmni.Api.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.0" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.0.28" />
     <PackageReference Include="AWSSDK.SimpleEmailV2" Version="4.0.5.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />

--- a/src/MeetlyOmni.Api/MeetlyOmni.Api.csproj
+++ b/src/MeetlyOmni.Api/MeetlyOmni.Api.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.0" />
+    <PackageReference Include="AWSSDK.SimpleEmailV2" Version="4.0.5.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />

--- a/src/MeetlyOmni.Api/Models/Auth/ForgotPasswordRequest.cs
+++ b/src/MeetlyOmni.Api/Models/Auth/ForgotPasswordRequest.cs
@@ -1,0 +1,17 @@
+// <copyright file="ForgotPasswordRequest.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using System.ComponentModel.DataAnnotations;
+
+namespace MeetlyOmni.Api.Models.Auth;
+
+public sealed class ForgotPasswordRequest
+{
+    /// <summary>
+    /// Gets email address to send password reset link to.
+    /// </summary>
+    [Required]
+    [EmailAddress]
+    public required string Email { get; init; }
+}

--- a/src/MeetlyOmni.Api/Models/Auth/ResetPasswordRequest.cs
+++ b/src/MeetlyOmni.Api/Models/Auth/ResetPasswordRequest.cs
@@ -1,0 +1,25 @@
+// <copyright file="ResetPasswordRequest.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using System.ComponentModel.DataAnnotations;
+
+namespace MeetlyOmni.Api.Models.Auth;
+
+public sealed class ResetPasswordRequest
+{
+    [Required]
+    public required string Token { get; init; }
+
+    [Required]
+    [EmailAddress]
+    public required string Email { get; init; }
+
+    [Required]
+    [StringLength(100, MinimumLength = 6, ErrorMessage = "Password must be at least 6 characters long.")]
+    public required string NewPassword { get; init; }
+
+    [Required]
+    [Compare("NewPassword", ErrorMessage = "The password and confirmation password do not match.")]
+    public required string ConfirmPassword { get; init; }
+}

--- a/src/MeetlyOmni.Api/Models/Auth/TokenValidationResponse.cs
+++ b/src/MeetlyOmni.Api/Models/Auth/TokenValidationResponse.cs
@@ -1,0 +1,14 @@
+// <copyright file="TokenValidationResponse.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+namespace MeetlyOmni.Api.Models.Auth;
+
+public sealed class TokenValidationResponse
+{
+    public bool IsValid { get; init; }
+
+    public string Message { get; init; } = string.Empty;
+
+    public string Email { get; init; } = string.Empty;
+}

--- a/src/MeetlyOmni.Api/Models/Auth/VerifyEmailRequest.cs
+++ b/src/MeetlyOmni.Api/Models/Auth/VerifyEmailRequest.cs
@@ -1,0 +1,17 @@
+// <copyright file="VerifyEmailRequest.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using System.ComponentModel.DataAnnotations;
+
+namespace MeetlyOmni.Api.Models.Auth;
+
+public sealed class VerifyEmailRequest
+{
+    [Required]
+    public required string Token { get; init; }
+
+    [Required]
+    [EmailAddress]
+    public required string Email { get; init; }
+}

--- a/src/MeetlyOmni.Api/Models/Email/EmailMessage.cs
+++ b/src/MeetlyOmni.Api/Models/Email/EmailMessage.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="EmailMessage.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+namespace MeetlyOmni.Api.Models.Email;
+
+public sealed class EmailMessage
+{
+    public required string To { get; init; }
+
+    public required string Subject { get; init; }
+
+    public required string HtmlBody { get; init; }
+
+    public required string TextBody { get; init; }
+}

--- a/src/MeetlyOmni.Api/Program.cs
+++ b/src/MeetlyOmni.Api/Program.cs
@@ -5,6 +5,9 @@
 using System.Buffers.Text;
 using System.IdentityModel.Tokens.Jwt;
 
+using Amazon;
+using Amazon.SimpleEmailV2;
+
 using Asp.Versioning;
 using Asp.Versioning.ApiExplorer;
 
@@ -110,6 +113,8 @@ builder.Services.AddSingleton<IEmailTemplateService, EmailTemplateService>();
 builder.Services.AddSingleton<IEmailSender, AwsSesEmailSender>();
 builder.Services.AddScoped<IEmailLinkService, EmailLinkService>();
 builder.Services.AddScoped<AccountMailer>();
+builder.Services.AddSingleton<IAmazonSimpleEmailServiceV2>(sp =>
+    new AmazonSimpleEmailServiceV2Client(RegionEndpoint.APSoutheast2));
 
 // Global exception handling is now handled by middleware
 

--- a/src/MeetlyOmni.Api/Program.cs
+++ b/src/MeetlyOmni.Api/Program.cs
@@ -100,6 +100,7 @@ builder.Services.AddScoped<ILoginService, LoginService>();
 builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddScoped<ILogoutService, LogoutService>();
 builder.Services.AddScoped<ISignUpService, SignUpService>();
+builder.Services.AddScoped<IResetPasswordService, ResetPasswordService>();
 
 // ---- Common Services ----
 builder.Services.AddScoped<IClientInfoService, ClientInfoService>();

--- a/src/MeetlyOmni.Api/Program.cs
+++ b/src/MeetlyOmni.Api/Program.cs
@@ -20,6 +20,8 @@ using MeetlyOmni.Api.Service.AuthService;
 using MeetlyOmni.Api.Service.AuthService.Interfaces;
 using MeetlyOmni.Api.Service.Common;
 using MeetlyOmni.Api.Service.Common.Interfaces;
+using MeetlyOmni.Api.Service.Email;
+using MeetlyOmni.Api.Service.Email.Interfaces;
 
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -101,6 +103,12 @@ builder.Services.AddScoped<ISignUpService, SignUpService>();
 
 // ---- Common Services ----
 builder.Services.AddScoped<IClientInfoService, ClientInfoService>();
+
+// Email Services
+builder.Services.AddSingleton<IEmailTemplateService, EmailTemplateService>();
+builder.Services.AddSingleton<IEmailSender, AwsSesEmailSender>();
+builder.Services.AddScoped<IEmailLinkService, EmailLinkService>();
+builder.Services.AddScoped<AccountMailer>();
 
 // Global exception handling is now handled by middleware
 

--- a/src/MeetlyOmni.Api/Service/AuthService/Interfaces/IResetPasswordService.cs
+++ b/src/MeetlyOmni.Api/Service/AuthService/Interfaces/IResetPasswordService.cs
@@ -1,0 +1,18 @@
+// <copyright file="IResetPasswordService.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+namespace MeetlyOmni.Api.Service.AuthService.Interfaces;
+
+public interface IResetPasswordService
+{
+    /// <summary>
+    /// Reset user password using a valid token.
+    /// </summary>
+    /// <param name="email">User email.</param>
+    /// <param name="token">Password reset token.</param>
+    /// <param name="newPassword">New password.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if password was successfully reset, false otherwise.</returns>
+    Task<bool> ResetPasswordAsync(string email, string token, string newPassword, CancellationToken ct = default);
+}

--- a/src/MeetlyOmni.Api/Service/AuthService/Interfaces/IResetPasswordService.cs
+++ b/src/MeetlyOmni.Api/Service/AuthService/Interfaces/IResetPasswordService.cs
@@ -2,6 +2,8 @@
 // Copyright (c) MeetlyOmni. All rights reserved.
 // </copyright>
 
+using Microsoft.AspNetCore.Identity;
+
 namespace MeetlyOmni.Api.Service.AuthService.Interfaces;
 
 public interface IResetPasswordService
@@ -13,6 +15,6 @@ public interface IResetPasswordService
     /// <param name="token">Password reset token.</param>
     /// <param name="newPassword">New password.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>True if password was successfully reset, false otherwise.</returns>
-    Task<bool> ResetPasswordAsync(string email, string token, string newPassword, CancellationToken ct = default);
+    /// <returns>IdentityResult containing success status and any error descriptions.</returns>
+    Task<IdentityResult> ResetPasswordAsync(string email, string token, string newPassword, CancellationToken ct = default);
 }

--- a/src/MeetlyOmni.Api/Service/AuthService/ResetPasswordService.cs
+++ b/src/MeetlyOmni.Api/Service/AuthService/ResetPasswordService.cs
@@ -2,12 +2,14 @@
 // Copyright (c) MeetlyOmni. All rights reserved.
 // </copyright>
 
+using System.Text;
 using System.Web;
 
 using MeetlyOmni.Api.Data.Entities;
 using MeetlyOmni.Api.Service.AuthService.Interfaces;
 
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 
 namespace MeetlyOmni.Api.Service.AuthService;
@@ -48,7 +50,7 @@ public sealed class ResetPasswordService : IResetPasswordService
             });
         }
 
-        var normalizedToken = HttpUtility.UrlDecode(token) ?? token;
+        var normalizedToken = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(token));
         var result = await _userManager.ResetPasswordAsync(user, normalizedToken, newPassword);
 
         if (result.Succeeded)

--- a/src/MeetlyOmni.Api/Service/AuthService/ResetPasswordService.cs
+++ b/src/MeetlyOmni.Api/Service/AuthService/ResetPasswordService.cs
@@ -27,6 +27,13 @@ public sealed class ResetPasswordService : IResetPasswordService
 
     public async Task<bool> ResetPasswordAsync(string email, string token, string newPassword, CancellationToken ct = default)
     {
+        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(newPassword))
+        {
+            _logger.LogWarning("ResetPassword: invalid input (email/token/password missing)");
+            return false;
+        }
+
+        ct.ThrowIfCancellationRequested();
         var user = await _userManager.FindByEmailAsync(email);
         if (user == null)
         {

--- a/src/MeetlyOmni.Api/Service/AuthService/ResetPasswordService.cs
+++ b/src/MeetlyOmni.Api/Service/AuthService/ResetPasswordService.cs
@@ -1,0 +1,51 @@
+// <copyright file="ResetPasswordService.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using System.Web;
+
+using MeetlyOmni.Api.Data.Entities;
+using MeetlyOmni.Api.Service.AuthService.Interfaces;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace MeetlyOmni.Api.Service.AuthService;
+
+public sealed class ResetPasswordService : IResetPasswordService
+{
+    private readonly UserManager<Member> _userManager;
+    private readonly ILogger<ResetPasswordService> _logger;
+
+    public ResetPasswordService(
+        UserManager<Member> userManager,
+        ILogger<ResetPasswordService> logger)
+    {
+        _userManager = userManager;
+        _logger = logger;
+    }
+
+    public async Task<bool> ResetPasswordAsync(string email, string token, string newPassword, CancellationToken ct = default)
+    {
+        var user = await _userManager.FindByEmailAsync(email);
+        if (user == null)
+        {
+            return false;
+        }
+
+        var normalizedToken = HttpUtility.UrlDecode(token) ?? token;
+        var result = await _userManager.ResetPasswordAsync(user, normalizedToken, newPassword);
+
+        if (result.Succeeded)
+        {
+            _logger.LogInformation("Password successfully reset for user {UserId}", user.Id);
+            return true;
+        }
+
+        _logger.LogWarning(
+            "Password reset failed for user {UserId}: {Errors}",
+            user.Id,
+            string.Join(", ", result.Errors.Select(e => e.Description)));
+        return false;
+    }
+}

--- a/src/MeetlyOmni.Api/Service/AuthService/SignUpService.cs
+++ b/src/MeetlyOmni.Api/Service/AuthService/SignUpService.cs
@@ -11,6 +11,7 @@ using MeetlyOmni.Api.Filters;
 using MeetlyOmni.Api.Models.Auth;
 using MeetlyOmni.Api.Models.Member;
 using MeetlyOmni.Api.Service.AuthService.Interfaces;
+using MeetlyOmni.Api.Service.Email;
 
 using Microsoft.AspNetCore.Identity;
 
@@ -25,19 +26,22 @@ public class SignUpService : ISignUpService
     private readonly IOrganizationRepository _organizationRepository;
     private readonly ApplicationDbContext _dbContext;
     private readonly ILogger<SignUpService> _logger;
+    private readonly AccountMailer _accountMailer;
 
     public SignUpService(
         UserManager<Member> userManager,
         RoleManager<ApplicationRole> roleManager,
         IOrganizationRepository organizationRepository,
         ApplicationDbContext dbContext,
-        ILogger<SignUpService> logger)
+        ILogger<SignUpService> logger,
+        AccountMailer accountMailer)
     {
         this._userManager = userManager;
         this._roleManager = roleManager;
         this._organizationRepository = organizationRepository;
         this._dbContext = dbContext;
         this._logger = logger;
+        this._accountMailer = accountMailer;
     }
 
     public async Task<MemberDto> SignUpAdminAsync(AdminSignupRequest request)
@@ -107,6 +111,10 @@ public class SignUpService : ISignUpService
 
             await this._dbContext.SaveChangesAsync();
             await transaction.CommitAsync();
+
+            // Send email verification after successful user creation
+            await this._accountMailer.SendVerifyEmailAsync(memberEntity);
+            _logger.LogInformation("Verification email sent to {Email}", memberEntity.Email);
 
             var dto = new MemberDto
             {

--- a/src/MeetlyOmni.Api/Service/AuthService/SignUpService.cs
+++ b/src/MeetlyOmni.Api/Service/AuthService/SignUpService.cs
@@ -112,9 +112,16 @@ public class SignUpService : ISignUpService
             await this._dbContext.SaveChangesAsync();
             await transaction.CommitAsync();
 
-            // Send email verification after successful user creation
-            await this._accountMailer.SendVerifyEmailAsync(memberEntity);
-            _logger.LogInformation("Verification email sent to {Email}", memberEntity.Email);
+            // Send email verification after successful user creation (non-blocking for UX)
+            try
+            {
+                await this._accountMailer.SendVerifyEmailAsync(memberEntity);
+                _logger.LogInformation("Verification email sent to {Email}", memberEntity.Email);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Signup succeeded but verification email failed to send to {Email}", memberEntity.Email);
+            }
 
             var dto = new MemberDto
             {

--- a/src/MeetlyOmni.Api/Service/Email/AccountMailer.cs
+++ b/src/MeetlyOmni.Api/Service/Email/AccountMailer.cs
@@ -55,9 +55,14 @@ public sealed class AccountMailer
         Func<Member, Task<string>> linkGenerator,
         CancellationToken ct)
     {
+        if (user is null)
+        {
+            throw new ArgumentNullException(nameof(user));
+        }
+
         if (string.IsNullOrWhiteSpace(user.Email))
         {
-            throw new InvalidOperationException("User email is required to send email.");
+            throw new ArgumentException("User email is required to send email.", nameof(user));
         }
 
         var link = await linkGenerator(user);

--- a/src/MeetlyOmni.Api/Service/Email/AccountMailer.cs
+++ b/src/MeetlyOmni.Api/Service/Email/AccountMailer.cs
@@ -24,7 +24,7 @@ public sealed class AccountMailer
     /// <summary>
     /// Send password reset email with secure token-based link.
     /// </summary>
-    /// <returns><placeholder>A <see cref="Task"/> representing the asynchronous operation.</placeholder></returns>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task<string> SendResetPasswordAsync(Member user, CancellationToken ct = default)
     {
         var resetLink = await _linkService.GeneratePasswordResetLinkAsync(user, ct);
@@ -38,7 +38,7 @@ public sealed class AccountMailer
     /// <summary>
     /// Send email verification with secure token-based link.
     /// </summary>
-    /// <returns><placeholder>A <see cref="Task"/> representing the asynchronous operation.</placeholder></returns>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task<string> SendVerifyEmailAsync(Member user, CancellationToken ct = default)
     {
         var verifyLink = await _linkService.GenerateEmailVerificationLinkAsync(user, ct);

--- a/src/MeetlyOmni.Api/Service/Email/AccountMailer.cs
+++ b/src/MeetlyOmni.Api/Service/Email/AccountMailer.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="AccountMailer.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using MeetlyOmni.Api.Common.Enums.EmailType;
+using MeetlyOmni.Api.Data.Entities;
+using MeetlyOmni.Api.Service.Email.Interfaces;
+
+namespace MeetlyOmni.Api.Service.Email;
+
+public sealed class AccountMailer
+{
+    private readonly IEmailTemplateService _tpl;
+    private readonly IEmailSender _sender;
+    private readonly IEmailLinkService _linkService;
+
+    public AccountMailer(IEmailTemplateService tpl, IEmailSender sender, IEmailLinkService linkService)
+    {
+        _tpl = tpl;
+        _sender = sender;
+        _linkService = linkService;
+    }
+
+    /// <summary>
+    /// Send password reset email with secure token-based link.
+    /// </summary>
+    /// <returns><placeholder>A <see cref="Task"/> representing the asynchronous operation.</placeholder></returns>
+    public async Task<string> SendResetPasswordAsync(Member user, CancellationToken ct = default)
+    {
+        var resetLink = await _linkService.GeneratePasswordResetLinkAsync(user, ct);
+        var msg = _tpl.Build(
+            EmailType.ResetPassword,
+            user.Email ?? string.Empty,
+            new Dictionary<string, string> { ["resetLink"] = resetLink });
+        return await _sender.SendAsync(msg, ct);
+    }
+
+    /// <summary>
+    /// Send email verification with secure token-based link.
+    /// </summary>
+    /// <returns><placeholder>A <see cref="Task"/> representing the asynchronous operation.</placeholder></returns>
+    public async Task<string> SendVerifyEmailAsync(Member user, CancellationToken ct = default)
+    {
+        var verifyLink = await _linkService.GenerateEmailVerificationLinkAsync(user, ct);
+        var msg = _tpl.Build(
+            EmailType.VerifyEmail,
+            user.Email ?? string.Empty,
+            new Dictionary<string, string> { ["verifyLink"] = verifyLink });
+        return await _sender.SendAsync(msg, ct);
+    }
+}

--- a/src/MeetlyOmni.Api/Service/Email/AwsSesEmailSender.cs
+++ b/src/MeetlyOmni.Api/Service/Email/AwsSesEmailSender.cs
@@ -52,17 +52,13 @@ public sealed class AwsSesEmailSender : IEmailSender
         {
             _logger.LogInformation(
                 "Attempting to send email. From={From} To={To} Region={Region}",
-                req.FromEmailAddress, message.To, _ses.Config.RegionEndpoint?.DisplayName);
+                req.FromEmailAddress,
+                message.To,
+                _ses.Config.RegionEndpoint?.DisplayName);
 
             var res = await _ses.SendEmailAsync(req, ct);
             _logger.LogInformation("SES email sent successfully. MessageId={MessageId} To={To}", res.MessageId, message.To);
             return res.MessageId;
-        }
-        catch (MessageRejectedException ex)
-        {
-            _logger.LogError(ex, "SES rejected email. From={From} To={To} Error={ErrorMessage}",
-                req.FromEmailAddress, message.To, ex.Message);
-            throw;
         }
         catch (Exception ex)
         {

--- a/src/MeetlyOmni.Api/Service/Email/AwsSesEmailSender.cs
+++ b/src/MeetlyOmni.Api/Service/Email/AwsSesEmailSender.cs
@@ -1,0 +1,68 @@
+﻿// <copyright file="AwsSesEmailSender.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using Amazon;
+using Amazon.SimpleEmailV2;
+using Amazon.SimpleEmailV2.Model;
+
+using MeetlyOmni.Api.Models.Email;
+using MeetlyOmni.Api.Service.Email.Interfaces;
+
+namespace MeetlyOmni.Api.Service.Email;
+public sealed class AwsSesEmailSender : IEmailSender
+{
+    private readonly IAmazonSimpleEmailServiceV2 _ses;
+    private readonly string _fromEmail;
+    private readonly string _fromName;
+    private readonly ILogger<AwsSesEmailSender> _logger;
+
+    public AwsSesEmailSender(IConfiguration cfg, ILogger<AwsSesEmailSender> logger)
+    {
+        _logger = logger;
+        _fromEmail = cfg["Ses:FromEmail"] ?? throw new ArgumentNullException("Ses:FromEmail");
+        _fromName = cfg["Ses:FromName"] ?? "MeetlyOmni";
+
+        // local variable/IAM role credentials
+        var region = RegionEndpoint.GetBySystemName(cfg["Ses:Region"] ?? "ap-southeast-2");
+        _ses = new AmazonSimpleEmailServiceV2Client(region);
+    }
+
+    public async Task<string> SendAsync(EmailMessage message, CancellationToken ct = default)
+    {
+        var req = new SendEmailRequest
+        {
+            FromEmailAddress = $"{_fromName} <{_fromEmail}>",
+            Destination = new Destination { ToAddresses = new List<string> { message.To } },
+            Content = new EmailContent
+            {
+                Simple = new Message
+                {
+                    Subject = new Content { Data = message.Subject, Charset = "UTF-8" },
+                    Body = new Body
+                    {
+                        Html = new Content { Data = message.HtmlBody, Charset = "UTF-8" },
+                        Text = new Content { Data = message.TextBody, Charset = "UTF-8" },
+                    },
+                },
+            },
+        };
+
+        try
+        {
+            var res = await _ses.SendEmailAsync(req, ct);
+            _logger.LogInformation("SES email sent. MessageId={MessageId} To={To}", res.MessageId, message.To);
+            return res.MessageId;
+        }
+        catch (MessageRejectedException ex)
+        {
+            _logger.LogError(ex, "SES rejected email. To={To}", message.To);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SES send failed. To={To}", message.To);
+            throw;
+        }
+    }
+}

--- a/src/MeetlyOmni.Api/Service/Email/EmailLinkService.cs
+++ b/src/MeetlyOmni.Api/Service/Email/EmailLinkService.cs
@@ -10,6 +10,7 @@ using MeetlyOmni.Api.Data.Entities;
 using MeetlyOmni.Api.Service.Email.Interfaces;
 
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace MeetlyOmni.Api.Service.Email;
 
@@ -39,7 +40,18 @@ public sealed class EmailLinkService : IEmailLinkService
     public async Task<string> GenerateEmailVerificationLinkAsync(Member user, CancellationToken ct = default)
     {
         var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-        var link = GenerateLink(token, user.Email, "/auth/verify-email");
+        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
+
+        var apiBase = _configuration["Backend:ApiBaseUrl"];
+        var userId = user.Id.ToString();
+        var email = user.Email ?? string.Empty;
+
+        var link =
+            $"{apiBase}/auth/verify-email" +
+            $"?userId={Uri.EscapeDataString(userId)}" +
+            $"&token={encodedToken}" +
+            $"&email={Uri.EscapeDataString(email)}";
+
         return link;
     }
 

--- a/src/MeetlyOmni.Api/Service/Email/EmailLinkService.cs
+++ b/src/MeetlyOmni.Api/Service/Email/EmailLinkService.cs
@@ -1,0 +1,169 @@
+// <copyright file="EmailLinkService.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Web;
+
+using MeetlyOmni.Api.Data.Entities;
+using MeetlyOmni.Api.Service.Email.Interfaces;
+
+using Microsoft.AspNetCore.Identity;
+
+namespace MeetlyOmni.Api.Service.Email;
+
+public sealed class EmailLinkService : IEmailLinkService
+{
+    private readonly UserManager<Member> _userManager;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<EmailLinkService> _logger;
+
+    public EmailLinkService(
+        UserManager<Member> userManager,
+        IConfiguration configuration,
+        ILogger<EmailLinkService> logger)
+    {
+        _userManager = userManager;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<string> GeneratePasswordResetLinkAsync(Member user, CancellationToken ct = default)
+    {
+        // Generate secure token using ASP.NET Core Identity
+        var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+
+        var encodedToken = HttpUtility.UrlEncode(token);
+        var encodedEmail = HttpUtility.UrlEncode(user.Email ?? string.Empty);
+
+        var frontendUrl = _configuration["Frontend:BaseUrl"] ?? "http://localhost:3000";
+
+        var resetLink = $"{frontendUrl}/auth/reset-password?token={encodedToken}&email={encodedEmail}";
+
+        _logger.LogInformation("Generated password reset link for user {UserId}", user.Id);
+
+        return resetLink;
+    }
+
+    public async Task<string> GenerateEmailVerificationLinkAsync(Member user, CancellationToken ct = default)
+    {
+        // Generate secure token using ASP.NET Core Identity
+        var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+
+        var encodedToken = HttpUtility.UrlEncode(token);
+        var encodedEmail = HttpUtility.UrlEncode(user.Email ?? string.Empty);
+
+        var frontendUrl = _configuration["Frontend:BaseUrl"] ?? "http://localhost:3000";
+
+        var verifyLink = $"{frontendUrl}/auth/verify-email?token={encodedToken}&email={encodedEmail}";
+
+        _logger.LogInformation("Generated email verification link for user {UserId}", user.Id);
+
+        return verifyLink;
+    }
+
+    public async Task<bool> ValidatePasswordResetTokenAsync(string email, string token, CancellationToken ct = default)
+    {
+        try
+        {
+            _logger.LogInformation("Validating password reset token for {Email}", email);
+
+            var user = await _userManager.FindByEmailAsync(email);
+            if (user == null)
+            {
+                _logger.LogWarning("Password reset validation failed: user not found for {Email}", email);
+                return false;
+            }
+
+            var isValid = await _userManager.VerifyUserTokenAsync(
+                user,
+                _userManager.Options.Tokens.PasswordResetTokenProvider,
+                "ResetPassword",
+                token);
+
+            _logger.LogInformation("Password reset token validation result for {Email}: {IsValid}", email, isValid);
+            return isValid;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error validating password reset token for {Email}", email);
+            return false;
+        }
+    }
+
+    public async Task<bool> ValidateAndConfirmEmailAsync(string email, string token, CancellationToken ct = default)
+    {
+        try
+        {
+            _logger.LogInformation("Validating and confirming email for {Email}", email);
+
+            var user = await _userManager.FindByEmailAsync(email);
+            if (user == null)
+            {
+                _logger.LogWarning("Email verification failed: user not found for {Email}", email);
+                return false;
+            }
+
+            if (user.EmailConfirmed)
+            {
+                _logger.LogInformation("Email already confirmed for {Email}", email);
+                return true; // Already confirmed, consider it success
+            }
+
+            var result = await _userManager.ConfirmEmailAsync(user, token);
+
+            if (result.Succeeded)
+            {
+                _logger.LogInformation("Email successfully confirmed for {Email}", email);
+                return true;
+            }
+            else
+            {
+                var errors = string.Join("; ", result.Errors.Select(e => e.Description));
+                _logger.LogWarning("Email confirmation failed for {Email}: {Errors}", email, errors);
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error validating email verification token for {Email}", email);
+            return false;
+        }
+    }
+
+    public async Task<bool> ResetPasswordAsync(string email, string token, string newPassword, CancellationToken ct = default)
+    {
+        try
+        {
+            _logger.LogInformation("Attempting password reset for {Email}", email);
+
+            var user = await _userManager.FindByEmailAsync(email);
+            if (user == null)
+            {
+                _logger.LogWarning("Password reset failed: user not found for {Email}", email);
+                return false;
+            }
+
+            // Reset the password using the token
+            var result = await _userManager.ResetPasswordAsync(user, token, newPassword);
+
+            if (result.Succeeded)
+            {
+                _logger.LogInformation("Password successfully reset for {Email}", email);
+                return true;
+            }
+            else
+            {
+                var errors = string.Join("; ", result.Errors.Select(e => e.Description));
+                _logger.LogWarning("Password reset failed for {Email}: {Errors}", email, errors);
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error resetting password for {Email}", email);
+            return false;
+        }
+    }
+}

--- a/src/MeetlyOmni.Api/Service/Email/EmailTemplateService.cs
+++ b/src/MeetlyOmni.Api/Service/Email/EmailTemplateService.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="EmailTemplateService.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using MeetlyOmni.Api.Common.Enums.EmailType;
+using MeetlyOmni.Api.Models.Email;
+using MeetlyOmni.Api.Service.Email.Interfaces;
+
+namespace MeetlyOmni.Api.Service.Email;
+
+public sealed class EmailTemplateService : IEmailTemplateService
+{
+    private readonly string _fromName;
+
+    public EmailTemplateService(IConfiguration config)
+    {
+        _fromName = config["Ses:FromName"] ?? "MeetlyOmni";
+    }
+
+    public EmailMessage Build(EmailType type, string to, IDictionary<string, string> data)
+    {
+        return type switch
+        {
+            EmailType.ResetPassword => BuildResetPassword(to, data),
+            EmailType.VerifyEmail => BuildVerifyEmail(to, data),
+            _ => throw new NotSupportedException(type.ToString())
+        };
+    }
+
+    private EmailMessage BuildResetPassword(string to, IDictionary<string, string> d)
+    {
+        var link = d["resetLink"];
+        var subject = "Reset your password";
+        var html = $@"
+            <div style=""font-family:Segoe UI,Arial,sans-serif;font-size:14px"">
+              <h2>Reset your password</h2>
+              <p>Click the button below to reset your password:</p>
+              <p><a href=""{link}"" 
+                    style=""background:#4f46e5;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;"">
+                    Reset Password
+                  </a></p>
+              <p>If you didn't request this, you can ignore this email.</p>
+              <hr/><p style=""color:#777"">{_fromName}</p>
+            </div>";
+
+        var text = $@"Reset your password
+
+Open the link to reset: {link}
+
+If you didn't request this, ignore this email.
+{_fromName}";
+
+        return new EmailMessage { To = to, Subject = subject, HtmlBody = html, TextBody = text };
+    }
+
+    private EmailMessage BuildVerifyEmail(string to, IDictionary<string, string> d)
+    {
+        var link = d["verifyLink"];
+        var subject = "Verify your email address";
+        var html = $@"
+            <div style=""font-family:Segoe UI,Arial,sans-serif;font-size:14px"">
+              <h2>Verify your email</h2>
+              <p>Thanks for signing up! Please confirm your email address:</p>
+              <p><a href=""{link}""
+                    style=""background:#16a34a;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;"">
+                    Verify Email
+                  </a></p>
+              <p>This link will expire soon for your security.</p>
+              <hr/><p style=""color:#777"">{_fromName}</p>
+            </div>";
+
+        var text = $@"Verify your email
+
+Please open the link to verify: {link}
+
+This link will expire soon.
+{_fromName}";
+
+        return new EmailMessage { To = to, Subject = subject, HtmlBody = html, TextBody = text };
+    }
+}

--- a/src/MeetlyOmni.Api/Service/Email/Interfaces/IEmailLinkService.cs
+++ b/src/MeetlyOmni.Api/Service/Email/Interfaces/IEmailLinkService.cs
@@ -14,7 +14,7 @@ public interface IEmailLinkService
 
     Task<bool> ValidatePasswordResetTokenAsync(string email, string token, CancellationToken ct = default);
 
-    Task<bool> ValidateAndConfirmEmailAsync(string email, string token, CancellationToken ct = default);
+    Task<bool> ValidateEmailVerificationTokenAsync(string email, string token, CancellationToken ct = default);
 
-    Task<bool> ResetPasswordAsync(string email, string token, string newPassword, CancellationToken ct = default);
+    Task<bool> ValidateAndConfirmEmailAsync(string email, string token, CancellationToken ct = default);
 }

--- a/src/MeetlyOmni.Api/Service/Email/Interfaces/IEmailLinkService.cs
+++ b/src/MeetlyOmni.Api/Service/Email/Interfaces/IEmailLinkService.cs
@@ -1,0 +1,20 @@
+// <copyright file="IEmailLinkService.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using MeetlyOmni.Api.Data.Entities;
+
+namespace MeetlyOmni.Api.Service.Email.Interfaces;
+
+public interface IEmailLinkService
+{
+    Task<string> GeneratePasswordResetLinkAsync(Member user, CancellationToken ct = default);
+
+    Task<string> GenerateEmailVerificationLinkAsync(Member user, CancellationToken ct = default);
+
+    Task<bool> ValidatePasswordResetTokenAsync(string email, string token, CancellationToken ct = default);
+
+    Task<bool> ValidateAndConfirmEmailAsync(string email, string token, CancellationToken ct = default);
+
+    Task<bool> ResetPasswordAsync(string email, string token, string newPassword, CancellationToken ct = default);
+}

--- a/src/MeetlyOmni.Api/Service/Email/Interfaces/IEmailSender.cs
+++ b/src/MeetlyOmni.Api/Service/Email/Interfaces/IEmailSender.cs
@@ -1,0 +1,12 @@
+﻿// <copyright file="IEmailSender.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using MeetlyOmni.Api.Models.Email;
+
+namespace MeetlyOmni.Api.Service.Email.Interfaces;
+
+public interface IEmailSender
+{
+    Task<string> SendAsync(EmailMessage message, CancellationToken ct = default);
+}

--- a/src/MeetlyOmni.Api/Service/Email/Interfaces/IEmailTemplateService.cs
+++ b/src/MeetlyOmni.Api/Service/Email/Interfaces/IEmailTemplateService.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="IEmailTemplateService.cs" company="MeetlyOmni">
+// Copyright (c) MeetlyOmni. All rights reserved.
+// </copyright>
+
+using MeetlyOmni.Api.Common.Enums.EmailType;
+using MeetlyOmni.Api.Models.Email;
+
+namespace MeetlyOmni.Api.Service.Email.Interfaces;
+
+public interface IEmailTemplateService
+{
+    EmailMessage Build(EmailType type, string to, IDictionary<string, string> data);
+}

--- a/src/MeetlyOmni.Api/appsettings.Development.json
+++ b/src/MeetlyOmni.Api/appsettings.Development.json
@@ -45,5 +45,8 @@
   },
   "Frontend": {
     "BaseUrl": "http://localhost:3000"
+  },
+  "Backend": {
+    "ApiBaseUrl": "https://localhost:7011/api/v1.0"
   }
 }

--- a/src/MeetlyOmni.Api/appsettings.Development.json
+++ b/src/MeetlyOmni.Api/appsettings.Development.json
@@ -37,5 +37,13 @@
   },
   "AntiforgeryProtection": {
     "CookieNames": [ "access_token", "refresh_token" ]
+  },
+  "Ses": {
+    "Region": "ap-southeast-2",
+    "FromEmail": "no-reply@meetlyomni.com",
+    "FromName": "MeetlyOmni"
+  },
+  "Frontend": {
+    "BaseUrl": "http://localhost:3000"
   }
 }

--- a/src/MeetlyOmni.Api/appsettings.Development.json
+++ b/src/MeetlyOmni.Api/appsettings.Development.json
@@ -40,7 +40,7 @@
   },
   "Ses": {
     "Region": "ap-southeast-2",
-    "FromEmail": "no-reply@meetlyomni.com",
+    "FromEmail": "meetlyomni@meetlyomni.com",
     "FromName": "MeetlyOmni"
   },
   "Frontend": {

--- a/src/MeetlyOmni.Unit.tests/Controllers/AuthControllerTests.cs
+++ b/src/MeetlyOmni.Unit.tests/Controllers/AuthControllerTests.cs
@@ -9,16 +9,20 @@ using FluentAssertions;
 using MeetlyOmni.Api.Common.Constants;
 using MeetlyOmni.Api.Common.Extensions;
 using MeetlyOmni.Api.Controllers;
+using MeetlyOmni.Api.Data.Entities;
 using MeetlyOmni.Api.Filters;
 using MeetlyOmni.Api.Models.Auth;
 using MeetlyOmni.Api.Models.Member;
 using MeetlyOmni.Api.Service.AuthService.Interfaces;
 using MeetlyOmni.Api.Service.Common.Interfaces;
+using MeetlyOmni.Api.Service.Email;
+using MeetlyOmni.Api.Service.Email.Interfaces;
 using MeetlyOmni.Unit.tests.Helpers;
 
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -43,6 +47,11 @@ public class AuthControllerTests
     private readonly Mock<ILogoutService> _mockLogoutService;
     private readonly Mock<ILogger<AuthController>> _mockLogger;
     private readonly Mock<ISignUpService> _mockSignUpService;
+    private readonly Mock<IEmailLinkService> _mockEmailLinkService;
+    private readonly AccountMailer _accountMailer;
+    private readonly Mock<UserManager<Member>> _mockUserManager;
+    private readonly Mock<IEmailTemplateService> _mockEmailTemplateService;
+    private readonly Mock<IEmailSender> _mockEmailSender;
 
     public AuthControllerTests()
     {
@@ -53,6 +62,20 @@ public class AuthControllerTests
         _mockLogoutService = new Mock<ILogoutService>();
         _mockLogger = new Mock<ILogger<AuthController>>();
         _mockSignUpService = new Mock<ISignUpService>();
+        _mockEmailLinkService = new Mock<IEmailLinkService>();
+        _mockEmailTemplateService = new Mock<IEmailTemplateService>();
+        _mockEmailSender = new Mock<IEmailSender>();
+
+        // Create AccountMailer real instance with mocked dependencies
+        _accountMailer = new AccountMailer(
+            _mockEmailTemplateService.Object,
+            _mockEmailSender.Object,
+            _mockEmailLinkService.Object);
+
+        // Create UserManager mock - requires specific setup
+        var mockUserStore = new Mock<IUserStore<Member>>();
+        _mockUserManager = new Mock<UserManager<Member>>(
+            mockUserStore.Object, null, null, null, null, null, null, null, null);
 
         _authController = new AuthController(
             _mockLoginService.Object,
@@ -61,7 +84,10 @@ public class AuthControllerTests
             _mockAntiforgery.Object,
             _mockLogger.Object,
             _mockLogoutService.Object,
-            _mockSignUpService.Object);
+            _mockSignUpService.Object,
+            _mockEmailLinkService.Object,
+            _accountMailer,
+            _mockUserManager.Object);
 
         SetupHttpContext();
     }

--- a/src/MeetlyOmni.Unit.tests/Controllers/AuthControllerTests.cs
+++ b/src/MeetlyOmni.Unit.tests/Controllers/AuthControllerTests.cs
@@ -52,6 +52,7 @@ public class AuthControllerTests
     private readonly Mock<UserManager<Member>> _mockUserManager;
     private readonly Mock<IEmailTemplateService> _mockEmailTemplateService;
     private readonly Mock<IEmailSender> _mockEmailSender;
+    private readonly Mock<IResetPasswordService> _mockResetPasswordService;
 
     public AuthControllerTests()
     {
@@ -65,6 +66,7 @@ public class AuthControllerTests
         _mockEmailLinkService = new Mock<IEmailLinkService>();
         _mockEmailTemplateService = new Mock<IEmailTemplateService>();
         _mockEmailSender = new Mock<IEmailSender>();
+        _mockResetPasswordService = new Mock<IResetPasswordService>();
 
         // Create AccountMailer real instance with mocked dependencies
         _accountMailer = new AccountMailer(
@@ -87,7 +89,8 @@ public class AuthControllerTests
             _mockSignUpService.Object,
             _mockEmailLinkService.Object,
             _accountMailer,
-            _mockUserManager.Object);
+            _mockUserManager.Object,
+            _mockResetPasswordService.Object);
 
         SetupHttpContext();
     }

--- a/src/MeetlyOmni.Unit.tests/Controllers/AuthControllerTests.cs
+++ b/src/MeetlyOmni.Unit.tests/Controllers/AuthControllerTests.cs
@@ -24,6 +24,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -53,6 +54,7 @@ public class AuthControllerTests
     private readonly Mock<IEmailTemplateService> _mockEmailTemplateService;
     private readonly Mock<IEmailSender> _mockEmailSender;
     private readonly Mock<IResetPasswordService> _mockResetPasswordService;
+    private readonly Mock<IConfiguration> _mockConfiguration;
 
     public AuthControllerTests()
     {
@@ -67,6 +69,7 @@ public class AuthControllerTests
         _mockEmailTemplateService = new Mock<IEmailTemplateService>();
         _mockEmailSender = new Mock<IEmailSender>();
         _mockResetPasswordService = new Mock<IResetPasswordService>();
+        _mockConfiguration = new Mock<IConfiguration>();
 
         // Create AccountMailer real instance with mocked dependencies
         _accountMailer = new AccountMailer(
@@ -90,7 +93,8 @@ public class AuthControllerTests
             _mockEmailLinkService.Object,
             _accountMailer,
             _mockUserManager.Object,
-            _mockResetPasswordService.Object);
+            _mockResetPasswordService.Object,
+            _mockConfiguration.Object);
 
         SetupHttpContext();
     }


### PR DESCRIPTION
- Write 2 email templet for both account verify and forget password verify
- Write a aws email sender service to enable email sending
<img width="983" height="461" alt="image" src="https://github.com/user-attachments/assets/7693309c-18a7-4bdb-b8b2-737394fa6682" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Email verification and password-reset flows added: token validation, verify email, request reset, perform reset; signup now triggers verification emails.

- **New Services**
  - Email templating, link generation, reset-password coordination, and AWS SES-based email sending integrated and registered.

- **Models / DTOs**
  - New request/response types plus EmailMessage and EmailType for email/token flows.

- **Configuration**
  - SES, Frontend and Backend URL settings added; AWS SDK packages included.

- **Tests**
  - Unit tests expanded to cover email and token flows.

- **Style**
  - StyleCop rule SA1206 suppressed.

- **Refactor**
  - Shared cookie deletion helper introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->