### PR TITLE
Hotfix aws credential

### DIFF
--- a/src/MeetlyOmni.Api/Common/Options/AWSOptions.cs
+++ b/src/MeetlyOmni.Api/Common/Options/AWSOptions.cs
@@ -6,74 +6,27 @@ using System;
 
 using Amazon;
 using Amazon.Runtime;
-using Amazon.Runtime.CredentialManagement;
 
 namespace MeetlyOmni.Api.Common.Options;
 
 public class AWSOptions
 {
-    public AWSCredentials Credentials { get; set; }
-
     public RegionEndpoint Region { get; set; }
 
     public string BucketName { get; set; }
 
-    /// <summary>
-    /// Initialize AWSOptions from a specified AWS profile.
-    /// Supports regular IAM profiles and SSO profiles.
-    /// </summary>
-    /// <param name="profileName">The AWS profile name.</param>
-    /// <param name="region">The AWS region, e.g. "ap-southeast-2".</param>
-    /// <param name="bucketName">The S3 bucket name.</param>
-    /// <returns>An AWSOptions instance.</returns>
-    public static AWSOptions FromProfile(string profileName, string region, string bucketName)
+    public AWSCredentials Credentials { get; set; } = null;
+
+    public static AWSOptions Create(string region, string bucketName)
     {
-        try
+        if (string.IsNullOrWhiteSpace(region)) throw new ArgumentException("Region is required", nameof(region));
+        if (string.IsNullOrWhiteSpace(bucketName)) throw new ArgumentException("BucketName is required", nameof(bucketName));
+
+        return new AWSOptions
         {
-            var chain = new CredentialProfileStoreChain();
-            if (chain.TryGetAWSCredentials(profileName, out var credentials))
-            {
-                return new AWSOptions
-                {
-                    Credentials = credentials,
-                    Region = Amazon.RegionEndpoint.GetBySystemName(region),
-                    BucketName = bucketName,
-                };
-            }
-
-            // Fallback: try environment variables
-            var envCredentials = new EnvironmentVariablesAWSCredentials();
-
-            // Try to get credentials from environment variables (throws if not found)
-            var creds = envCredentials.GetCredentials();
-            return new AWSOptions
-            {
-                Credentials = envCredentials,
-                Region = Amazon.RegionEndpoint.GetBySystemName(region),
-                BucketName = bucketName,
-            };
-        }
-        catch (Exception ex)
-        {
-            // Fallback: use default profile if available
-            var chain = new CredentialProfileStoreChain();
-            if (chain.TryGetAWSCredentials("default", out var defaultCredentials))
-            {
-                return new AWSOptions
-                {
-                    Credentials = defaultCredentials,
-                    Region = Amazon.RegionEndpoint.GetBySystemName(region),
-                    BucketName = bucketName,
-                };
-            }
-
-            // Fallback: use anonymous credentials for local/mock/test
-            return new AWSOptions
-            {
-                Credentials = new AnonymousAWSCredentials(),
-                Region = Amazon.RegionEndpoint.GetBySystemName(region),
-                BucketName = bucketName,
-            };
-        }
+            Region = RegionEndpoint.GetBySystemName(region),
+            BucketName = bucketName,
+            Credentials = null
+        };
     }
 }

--- a/src/MeetlyOmni.Api/Program.cs
+++ b/src/MeetlyOmni.Api/Program.cs
@@ -233,29 +233,22 @@ builder.Services.Configure<AntiforgeryProtectionOptions>(
 
 // Amazon S3 Configuration
 var awsSection = builder.Configuration.GetSection("AWS");
-var isCi = Environment.GetEnvironmentVariable("CI") == "true";
-var profileName = awsSection["Profile"] ?? (isCi ? string.Empty : throw new InvalidOperationException("AWS:Profile is not configured."));
-var region = awsSection["Region"] ?? (isCi ? string.Empty : throw new InvalidOperationException("AWS:Region is not configured."));
-var bucketName = awsSection["BucketName"] ?? (isCi ? string.Empty : throw new InvalidOperationException("AWS:BucketName is not configured."));
-
-Console.WriteLine($"AWS Profile: {profileName}");
-Console.WriteLine($"AWS Region: {region}");
-Console.WriteLine($"AWS Bucket: {bucketName}");
-
-if (isCi && (string.IsNullOrEmpty(profileName) || string.IsNullOrEmpty(region) || string.IsNullOrEmpty(bucketName)))
-{
-    Console.WriteLine("Running in CI: skipping AWS initialization.");
-}
+var region = awsSection["Region"] ?? throw new InvalidOperationException("AWS:Region is not configured.");
+var bucketName = awsSection["BucketName"] ?? throw new InvalidOperationException("AWS:BucketName is not configured.");
 
 // Initialize AWSOptions using the profile
-var awsOptions = AWSOptions.FromProfile(profileName, region, bucketName);
+var awsOptions = new AWSOptions
+{
+    Region = Amazon.RegionEndpoint.GetBySystemName(region),
+    BucketName = bucketName
+};
 
 // Register AWSOptions and S3 client in DI
 builder.Services.AddSingleton(awsOptions);
 builder.Services.AddSingleton<IAmazonS3>(sp =>
 {
     var options = sp.GetRequiredService<AWSOptions>();
-    return new AmazonS3Client(options.Credentials, options.Region);
+    return new AmazonS3Client(options.Region);
 });
 
 builder.Services.AddControllers();

--- a/src/MeetlyOmni.Api/appsettings.Development.json
+++ b/src/MeetlyOmni.Api/appsettings.Development.json
@@ -50,9 +50,7 @@
     "ApiBaseUrl": "https://localhost:7011/api/v1.0"
   },
   "AWS": {
-    "Profile": "prod",
     "Region": "ap-southeast-2",
-    "BucketName": "meetlyomni-prod-media",
-    "ProjectName": "meetlyomni"
+    "BucketName": "meetlyomni-prod-media"
   }
 }

--- a/src/MeetlyOmni.Api/appsettings.json
+++ b/src/MeetlyOmni.Api/appsettings.json
@@ -34,10 +34,8 @@
     "ApiBaseUrl": "https://api.meetlyomni.com/api/v1"
   },
   "AWS": {
-    "Profile": "prod",
     "Region": "ap-southeast-2",
-    "BucketName": "meetlyomni-prod-media",
-    "ProjectName": "meetlyomni"
+    "BucketName": "meetlyomni-prod-media"
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified AWS setup: removed profile-based credential handling; now relies on region with automatically discovered credentials when available.
  * Enforced stricter configuration validation: missing/invalid region or bucket will fail fast at startup.
  * Streamlined S3 client initialization to reduce configuration complexity.

* **Chores**
  * Cleaned configuration: removed AWS Profile and ProjectName settings from app settings (both default and development). Bucket setting remains.

Note: If you previously used profile/project settings, ensure environment/instance credentials are available and region/bucket are correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->